### PR TITLE
Fix FDTI Driver

### DIFF
--- a/src/ftdi.rs
+++ b/src/ftdi.rs
@@ -1,6 +1,7 @@
 use super::*;
 use byteorder::{BigEndian, ByteOrder};
 use safe_ftdi as ftdi;
+use ftdi::mpsse::MpsseMode;
 
 pub struct R64DriveFtdi<'a> {
     context: ftdi::Context,
@@ -30,6 +31,12 @@ impl<'a> R64DriveFtdi<'a> {
             _dummy: std::marker::PhantomData,
         };
         result.context.open(0x0403, 0x6014).unwrap();
+
+        // Initialize/reset hardware (HW2 only?)
+        result.context.set_bitmode(0xFF, MpsseMode::BITMODE_RESET).unwrap();
+        result.context.set_bitmode(0xFF, MpsseMode::BITMODE_SYNCFF).unwrap();
+        result.recv_u32().unwrap();
+
         result
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,9 @@
+use r64drive::ftdi::R64DriveFtdi;
+use r64drive::R64Drive;
+
+fn main() {
+    let driver = R64DriveFtdi::new();
+    let r64d = R64Drive::new(&driver);
+    let (variant, version) = r64d.get_version().expect("get_version error");
+    println!("variant: {:?}, version: {}", variant, version);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -14,6 +14,7 @@ enum State {
     SetCICType,
     SetCIExtended,
     VersionRequest,
+    SendMagic,
     Finished,
 }
 
@@ -115,6 +116,7 @@ impl R64DriveTest {
             }
             State::DumpToPCData => Err(("invalid packet in state DumpToPCData", val)),
             State::VersionRequest => Err(("invalid packet in state VersionRequest", val)),
+            State::SendMagic => Err(("invalid packet in state SendMagic", val)),
             State::Finished => Err(("invalid packet in state Finished", val)),
         }
     }
@@ -123,8 +125,12 @@ impl R64DriveTest {
         match self.state {
             State::Idle => Err(("unexpected read in state Idle", 0)),
             State::VersionRequest => {
-                self.state = State::Finished;
+                self.state = State::SendMagic;
                 Ok(0x4200_00CD)
+            }
+            State::SendMagic => {
+                self.state = State::Finished;
+                Ok(0x5544_4556)
             }
             State::SetSaveType => Err(("unexpected read in state SetSaveType", 0)),
             State::SetCICType => Err(("unexpected read in state SetCICType", 0)),


### PR DESCRIPTION
I don't know why the additional `recv_u32()` call is necessary. Without it, the first word read after the command is zeros... The "UDEV" string is documented as the magic value, but is not mentioned in the response for the version command.

This fixes the FTDI driver initialization and the `get_version` command. I also added a sample executable that prints the version info from hardware.