### PR TITLE
Updates for FTDI driver and PoC executable

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -9,3 +9,6 @@ pub const MAGIC: u32 = 0x55_44_45_56;
 
 /// Override default CIC type
 pub const OVERRIDE_CIC: u32 = 0x8000_0000;
+
+/// Maximum data transfer size (in bytes)
+pub const MAX_TRANSFER_SIZE: usize = 8 * 1024 * 1024 / 4;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -6,3 +6,6 @@ pub const COMPARE: u32 = 0x43_4D_50_00;
 
 /// Device magic number: "UDEV"
 pub const MAGIC: u32 = 0x55_44_45_56;
+
+/// Override default CIC type
+pub const OVERRIDE_CIC: u32 = 0x8000_0000;

--- a/src/ftdi.rs
+++ b/src/ftdi.rs
@@ -1,5 +1,5 @@
 use super::*;
-use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
+use byteorder::{BigEndian, ByteOrder};
 use ftdi::mpsse::MpsseMode;
 use safe_ftdi as ftdi;
 
@@ -23,23 +23,18 @@ impl R64Driver for R64DriveFtdi {
 
     fn send_u32_slice(&self, slice: &[u32]) -> Result<usize, Self::Error> {
         let mut buf = Vec::with_capacity(4 * slice.len());
-        let buf_wtr = &mut buf;
-        for &val in slice {
-            buf_wtr
-                .write_u32::<BigEndian>(val)
-                .expect("Error writing to vector");
-        }
+        buf.resize(4 * slice.len(), 0);
+        BigEndian::write_u32_into(slice, &mut buf);
         self.context.write_data(&buf).map(|x| x as usize)
     }
 
     fn recv_u32_slice(&self, len: usize) -> Result<Vec<u32>, Self::Error> {
         let mut buf = Vec::with_capacity(4 * len);
+        buf.resize(4 * len, 0);
         self.context.read_data(&mut buf)?;
-        let mut buf_rdr: &[u8] = &mut buf;
         let mut result = Vec::with_capacity(len);
-        while let Ok(val) = buf_rdr.read_u32::<BigEndian>() {
-            result.push(val);
-        }
+        result.resize(len, 0);
+        BigEndian::read_u32_into(&buf, &mut result);
         Ok(result)
     }
 }

--- a/src/ftdi.rs
+++ b/src/ftdi.rs
@@ -22,18 +22,15 @@ impl R64Driver for R64DriveFtdi {
     }
 
     fn send_u32_slice(&self, slice: &[u32]) -> Result<usize, Self::Error> {
-        let mut buf = Vec::with_capacity(4 * slice.len());
-        buf.resize(4 * slice.len(), 0);
+        let mut buf = vec![0; 4 * slice.len()];
         BigEndian::write_u32_into(slice, &mut buf);
         self.context.write_data(&buf).map(|x| x as usize)
     }
 
     fn recv_u32_slice(&self, len: usize) -> Result<Vec<u32>, Self::Error> {
-        let mut buf = Vec::with_capacity(4 * len);
-        buf.resize(4 * len, 0);
+        let mut buf = vec![0; 4 * len];
         self.context.read_data(&mut buf)?;
-        let mut result = Vec::with_capacity(len);
-        result.resize(len, 0);
+        let mut result = vec![0; len];
         BigEndian::read_u32_into(&buf, &mut result);
         Ok(result)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,6 @@ where
         cmd_id: Command,
         args: &[u32],
         expected_len: usize,
-        verify: bool,
     ) -> Result<Vec<u32>, R64DriveError<T::Error>> {
         let cmd_hdr = ((cmd_id as u32) << 24) | consts::COMMAND;
         self.driver.send_u32(cmd_hdr)?;
@@ -132,11 +131,14 @@ where
 
         let response = self.driver.recv_u32_slice(expected_len)?;
 
-        if verify {
-            let completion_pkt = (cmd_id as u32) | consts::COMPARE;
-            let resp_u32 = self.driver.recv_u32()?;
-            if resp_u32 != completion_pkt {
-                return Err(InvalidCompletion(resp_u32));
+        match cmd_id {
+            Command::LoadFromPC | Command::DumpToPC => {}
+            _ => {
+                let completion_pkt = (cmd_id as u32) | consts::COMPARE;
+                let resp_u32 = self.driver.recv_u32()?;
+                if resp_u32 != completion_pkt {
+                    return Err(InvalidCompletion(resp_u32));
+                }
             }
         }
 
@@ -146,7 +148,7 @@ where
     pub fn get_version(
         &self,
     ) -> Result<(HardwareVariant, FirmwareVersion), R64DriveError<T::Error>> {
-        let response = self.send_cmd(Command::VersionRequest, &[], 2, true)?;
+        let response = self.send_cmd(Command::VersionRequest, &[], 2)?;
         if response[1] != consts::MAGIC {
             Err(InvalidMagic(response[1]))?;
         }
@@ -157,7 +159,7 @@ where
     }
 
     pub fn set_save_type(&self, save_type: SaveType) -> Result<(), R64DriveError<T::Error>> {
-        self.send_cmd(Command::SetSaveType, &[save_type as u32], 0, true)
+        self.send_cmd(Command::SetSaveType, &[save_type as u32], 0)
             .map(|_| ())
     }
 
@@ -166,13 +168,12 @@ where
             Command::SetCICType,
             &[cic_type as u32 | consts::OVERRIDE_CIC],
             0,
-            true,
         )
         .map(|_| ())
     }
 
     pub fn set_ci_extended(&self, enable: bool) -> Result<(), R64DriveError<T::Error>> {
-        self.send_cmd(Command::SetCIExtended, &[enable as u32], 0, true)
+        self.send_cmd(Command::SetCIExtended, &[enable as u32], 0)
             .map(|_| ())
     }
 
@@ -189,8 +190,7 @@ where
         args.push(offset);
         args.push((bank as u32) << 24 | (data.len() * 4) as u32);
         args.extend(data);
-        self.send_cmd(Command::LoadFromPC, &args, 0, false)
-            .map(|_| ())
+        self.send_cmd(Command::LoadFromPC, &args, 0).map(|_| ())
     }
 
     pub fn dump_to_pc(
@@ -206,7 +206,6 @@ where
             Command::DumpToPC,
             &[offset, (bank as u32) << 24 | len],
             (len / 4) as usize,
-            false,
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ where
     }
 
     pub fn set_cic_type(&self, cic_type: CICType) -> Result<(), R64DriveError<T::Error>> {
-        self.send_cmd(Command::SetCICType, &[cic_type as u32], 0)
+        self.send_cmd(Command::SetCICType, &[cic_type as u32 | consts::OVERRIDE_CIC], 0)
             .map(|_| ())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,8 +162,13 @@ where
     }
 
     pub fn set_cic_type(&self, cic_type: CICType) -> Result<(), R64DriveError<T::Error>> {
-        self.send_cmd(Command::SetCICType, &[cic_type as u32 | consts::OVERRIDE_CIC], 0, true)
-            .map(|_| ())
+        self.send_cmd(
+            Command::SetCICType,
+            &[cic_type as u32 | consts::OVERRIDE_CIC],
+            0,
+            true,
+        )
+        .map(|_| ())
     }
 
     pub fn set_ci_extended(&self, enable: bool) -> Result<(), R64DriveError<T::Error>> {
@@ -184,7 +189,8 @@ where
         args.push(offset);
         args.push((bank as u32) << 24 | (data.len() * 4) as u32);
         args.extend(data);
-        self.send_cmd(Command::LoadFromPC, &args, 0, false).map(|_| ())
+        self.send_cmd(Command::LoadFromPC, &args, 0, false)
+            .map(|_| ())
     }
 
     pub fn dump_to_pc(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,9 @@ where
         bank: BankIndex,
         data: &[u32],
     ) -> Result<(), R64DriveError<T::Error>> {
+        // TODO: Upload 8MB at a time instead of asserting on the length
+        assert!(data.len() <= consts::MAX_TRANSFER_SIZE);
+
         let mut args: Vec<u32> = Vec::with_capacity(data.len() + 2);
         args.push(offset);
         args.push((bank as u32) << 24 | (data.len() * 4) as u32);
@@ -190,6 +193,9 @@ where
         bank: BankIndex,
         len: u32,
     ) -> Result<Vec<u32>, R64DriveError<T::Error>> {
+        // TODO: Download 8MB at a time instead of asserting on the length
+        assert!((len as usize) <= consts::MAX_TRANSFER_SIZE);
+
         self.send_cmd(
             Command::DumpToPC,
             &[offset, (bank as u32) << 24 | len],

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,7 @@ fn main() -> Result<(), Error> {
 
         // Read ROM file into Vec<u32>
         let size = f.len() / mem::size_of::<u32>();
-        let mut rom = Vec::with_capacity(size);
-        rom.resize(size, 0);
+        let mut rom = vec![0; size];
 
         println!("Uploading {} bytes...", f.len());
         BigEndian::read_u32_into(&f, &mut rom);

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,10 +66,11 @@ fn main() -> Result<(), Error> {
         // Read ROM file into Vec<u32>
         let size = f.len() / mem::size_of::<u32>();
         let mut rom = vec![0; size];
-
-        println!("Uploading {} bytes...", f.len());
         BigEndian::read_u32_into(&f, &mut rom);
+
+        println!("Uploading {} bytes...", rom.len() * 4);
         r64d.load_from_pc(0, BankIndex::CartridgeROM, &rom)?;
+
         println!("Done!");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,16 @@ enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match self {
-            Error::Driver => "Generic driver error",
-            Error::Io => "Unable to read file",
-            Error::NotN64 => "Provided file is not an N64 ROM",
-            Error::RomSize => "Provided file is too small for N64",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                Error::Driver => "Generic driver error",
+                Error::Io => "Unable to read file",
+                Error::NotN64 => "Provided file is not an N64 ROM",
+                Error::RomSize => "Provided file is too small for N64",
+            }
+        )
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,74 @@
+use byteorder::{BigEndian, ByteOrder};
 use r64drive::ftdi::R64DriveFtdi;
-use r64drive::R64Drive;
+use r64drive::{BankIndex, CICType, R64Drive, R64DriveError};
+use std::{env, fmt, fs, io, mem};
 
-fn main() {
+enum Error {
+    Driver,
+    Io,
+    NotN64,
+    RomSize,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match self {
+            Error::Driver => "Generic driver error",
+            Error::Io => "Unable to read file",
+            Error::NotN64 => "Provided file is not an N64 ROM",
+            Error::RomSize => "Provided file is too small for N64",
+        })
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error {{ {} }}", self)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(_error: io::Error) -> Self {
+        Error::Io
+    }
+}
+
+impl<T> From<R64DriveError<T>> for Error {
+    fn from(_error: R64DriveError<T>) -> Self {
+        Error::Driver
+    }
+}
+
+fn main() -> Result<(), Error> {
     let driver = R64DriveFtdi::new();
     let r64d = R64Drive::new(&driver);
-    let (variant, version) = r64d.get_version().expect("get_version error");
+    let (variant, version) = r64d.get_version()?;
     println!("variant: {:?}, version: {}", variant, version);
+
+    r64d.set_cic_type(CICType::CIC6102)?;
+
+    let mut args = env::args().skip(1);
+    if let Some(filepath) = args.next() {
+        let f = fs::read(filepath)?;
+
+        // Basic sanity checks; ensure this is an N64 ROM, non-byte-swapped
+        if f.len() < 0x10_1000 {
+            Err(Error::RomSize)?;
+        }
+        if BigEndian::read_u32(&f) != 0x8037_1240 {
+            Err(Error::NotN64)?;
+        }
+
+        // Read ROM file into Vec<u32>
+        let size = f.len() / mem::size_of::<u32>();
+        let mut rom = Vec::with_capacity(size);
+        rom.resize(size, 0);
+
+        println!("Uploading {} bytes...", f.len());
+        BigEndian::read_u32_into(&f, &mut rom);
+        r64d.load_from_pc(0, BankIndex::CartridgeROM, &rom)?;
+        println!("Done!");
+    }
+
+    Ok(())
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -152,7 +152,7 @@ impl R64DriveTest {
             State::SendValidation => {
                 self.state = State::Finished;
                 Ok(0x43_4D_50_00u32 | self.command as u32)
-            },
+            }
             State::Finished => Err(("unexpected read in state Finished", 0)),
         }
     }


### PR DESCRIPTION
- `get_version()` was failing with error: `InvalidCompletion(1107296461)`. I didn't look into the cause, but changing the slice impls fixed it.
- Update `set_cic_type()` to set the MSB, as mentioned in the hardware doc.
- Fixes some protocol expectations for `load_from_pc()` and `dump_to_pc()`.
- Update PoC executable to set the CIC to 6102 and upload (up to 8MB) N64 ROMs; Super Mario 64 works!